### PR TITLE
Add optional strace support for logger launch

### DIFF
--- a/benchmark/config.json
+++ b/benchmark/config.json
@@ -5,6 +5,7 @@
   "loggerConfigPath": "config.yml",
   "outputFilePath": "flow_event.json",
   "scenarioPath": "scenarios.json",
+  "strace": "disabled",
 
   "generatorParams": {
     "host": "127.0.0.1",

--- a/benchmark/include/config.h
+++ b/benchmark/include/config.h
@@ -17,6 +17,7 @@ struct Config {
     std::string loggerConfigPath;
     std::string outputFilePath;
     std::string scenarioPath;
+    bool        straceEnabled;   // run logger via strace
     GeneratorParams generatorParams;
 };
 

--- a/benchmark/include/logger_launcher.h
+++ b/benchmark/include/logger_launcher.h
@@ -13,4 +13,14 @@ pid_t launchBinaryLogger(const std::string& path,
                          int port,
                          const std::string& configPath);
 
+pid_t launchPythonLoggerStrace(const std::string& moduleName,
+                               const std::string& host,
+                               int port,
+                               const std::string& configPath);
+
+pid_t launchBinaryLoggerStrace(const std::string& path,
+                               const std::string& host,
+                               int port,
+                               const std::string& configPath);
+
 #endif // LOGGER_LAUNCHER_H

--- a/benchmark/src/config.cpp
+++ b/benchmark/src/config.cpp
@@ -21,6 +21,7 @@ Config loadConfig(const std::string& path) {
         cfg.loggerConfigPath = "config.yml";
         cfg.outputFilePath   = "flow_event.json";
         cfg.scenarioPath     = "scenarios.json";
+        cfg.straceEnabled    = false;
         cfg.generatorParams  = {"127.0.0.1", 7000, 1.0, 128};
         return cfg;
     }
@@ -36,6 +37,7 @@ Config loadConfig(const std::string& path) {
     cfg.loggerConfigPath = j.value("loggerConfigPath", "config.yml");
     cfg.outputFilePath   = j.value("outputFilePath", "flow_event.json");
     cfg.scenarioPath     = j.value("scenarioPath", "scenarios.json");
+    cfg.straceEnabled    = (j.value("strace", "disabled") == "enabled");
 
     // Generator-Params
     auto gj = j["generatorParams"];

--- a/benchmark/src/logger_launcher.cpp
+++ b/benchmark/src/logger_launcher.cpp
@@ -44,3 +44,49 @@ pid_t launchBinaryLogger(const std::string& path,
     }
     return pid;
 }
+
+pid_t launchPythonLoggerStrace(const std::string& moduleName,
+                               const std::string& host,
+                               int port,
+                               const std::string& configPath) {
+    pid_t pid = fork();
+    if (pid == 0) {
+        execlp("strace", "strace",
+               "-f", "-c", "-o", "strace_summary.log",
+               "python3", "-m", moduleName.c_str(),
+               "--host", host.c_str(),
+               "--port", std::to_string(port).c_str(),
+               "--write", ".",
+               "--config", configPath.c_str(),
+               "--show-flow-events", "1",
+               nullptr);
+        std::cerr << "Failed to launch heiDPI_logger with strace" << std::endl;
+        _exit(1);
+    } else if (pid < 0) {
+        std::cerr << "Fork failed" << std::endl;
+    }
+    return pid;
+}
+
+pid_t launchBinaryLoggerStrace(const std::string& path,
+                               const std::string& host,
+                               int port,
+                               const std::string& configPath) {
+    pid_t pid = fork();
+    if (pid == 0) {
+        execlp("strace", "strace",
+               "-f", "-c", "-o", "strace_summary.log",
+               path.c_str(),
+               "--host", host.c_str(),
+               "--port", std::to_string(port).c_str(),
+               "--write", ".",
+               "--config", configPath.c_str(),
+               "--show-flow-events", "1",
+               nullptr);
+        std::cerr << "Failed to launch heiDPI logger binary with strace" << std::endl;
+        _exit(1);
+    } else if (pid < 0) {
+        std::cerr << "Fork failed" << std::endl;
+    }
+    return pid;
+}

--- a/benchmark/src/main.cpp
+++ b/benchmark/src/main.cpp
@@ -57,18 +57,34 @@ int main(int argc, char* argv[]) {
 
     // 3. Launch heiDPI_logger after socket exists
     pid_t loggerPid = -1;
-    if (config.loggerType == "binary") {
-        loggerPid = launchBinaryLogger(
-            config.loggerBinary,
-            config.generatorParams.host,
-            config.generatorParams.port,
-            config.loggerConfigPath);
+    if (config.straceEnabled) {
+        if (config.loggerType == "binary") {
+            loggerPid = launchBinaryLoggerStrace(
+                config.loggerBinary,
+                config.generatorParams.host,
+                config.generatorParams.port,
+                config.loggerConfigPath);
+        } else {
+            loggerPid = launchPythonLoggerStrace(
+                config.loggerModule,
+                config.generatorParams.host,
+                config.generatorParams.port,
+                config.loggerConfigPath);
+        }
     } else {
-        loggerPid = launchPythonLogger(
-            config.loggerModule,
-            config.generatorParams.host,
-            config.generatorParams.port,
-            config.loggerConfigPath);
+        if (config.loggerType == "binary") {
+            loggerPid = launchBinaryLogger(
+                config.loggerBinary,
+                config.generatorParams.host,
+                config.generatorParams.port,
+                config.loggerConfigPath);
+        } else {
+            loggerPid = launchPythonLogger(
+                config.loggerModule,
+                config.generatorParams.host,
+                config.generatorParams.port,
+                config.loggerConfigPath);
+        }
     }
     loggerStarted = true;
     std::cout << "Started heiDPI_logger (PID: " << loggerPid << ")" << std::endl;


### PR DESCRIPTION
## Summary
- make benchmark read `strace` setting from config.json
- add strace-enabled launchers for Python module and binary logger
- call strace launchers when enabled in configuration

## Testing
- `cmake -S benchmark -B build_benchmark`
- `cmake --build build_benchmark`

------
https://chatgpt.com/codex/tasks/task_e_68964b74c7808332a6f4380857b17df5