### PR TITLE
Refactor logger with async queue and log level

### DIFF
--- a/port2-reduce-futex/include/Logger.hpp
+++ b/port2-reduce-futex/include/Logger.hpp
@@ -1,7 +1,12 @@
 #pragma once
+#include <condition_variable>
 #include <fstream>
 #include <mutex>
+#include <queue>
 #include <string>
+#include <thread>
+#include <utility>
+
 #include "Config.hpp"
 
 /**
@@ -9,11 +14,25 @@
  */
 class Logger {
 public:
+    enum class Level { ERROR = 0, INFO = 1 };
+
     static void init(const LoggingConfig &cfg);
+    static void shutdown();
     static void info(const std::string &msg);
     static void error(const std::string &msg);
+
 private:
-    static std::mutex mtx;
+    static void worker();
+
+    static std::mutex queue_mtx;
+    static std::condition_variable cv;
+    static std::queue<std::pair<Level, std::string>> queue;
+    static bool running;
+    static std::thread thread;
+
+    static std::mutex console_mtx;
+    static std::mutex file_mtx;
     static std::ofstream file;
+    static Level current_level;
 };
 

--- a/port2-reduce-futex/src/Logger.cpp
+++ b/port2-reduce-futex/src/Logger.cpp
@@ -1,11 +1,21 @@
 #include "Logger.hpp"
-#include <iostream>
-#include <chrono>
-#include <iomanip>
-#include <ctime>
 
-std::mutex Logger::mtx;
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <cstdlib>
+
+std::mutex Logger::queue_mtx;
+std::condition_variable Logger::cv;
+std::queue<std::pair<Logger::Level, std::string>> Logger::queue;
+bool Logger::running = false;
+std::thread Logger::thread;
+
+std::mutex Logger::console_mtx;
+std::mutex Logger::file_mtx;
 std::ofstream Logger::file;
+Logger::Level Logger::current_level = Logger::Level::INFO;
 
 static std::string timestamp() {
     auto now = std::chrono::system_clock::now();
@@ -17,22 +27,67 @@ static std::string timestamp() {
 }
 
 void Logger::init(const LoggingConfig &cfg) {
+    current_level = (cfg.level == "ERROR") ? Level::ERROR : Level::INFO;
     if (!cfg.filename.empty()) {
         file.open(cfg.filename, std::ios::app);
+    }
+    running = true;
+    thread = std::thread(worker);
+    std::atexit(Logger::shutdown);
+}
+
+void Logger::shutdown() {
+    {
+        std::lock_guard<std::mutex> lock(queue_mtx);
+        running = false;
+    }
+    cv.notify_all();
+    if (thread.joinable()) thread.join();
+    if (file.is_open()) {
+        std::lock_guard<std::mutex> lk(file_mtx);
+        file.close();
     }
 }
 
 void Logger::info(const std::string &msg) {
-    std::lock_guard<std::mutex> lock(mtx);
+    if (current_level < Level::INFO) return;
     std::string line = timestamp() + " INFO: " + msg + "\n";
-    std::cout << line;
-    if (file.is_open()) file << line;
+    {
+        std::lock_guard<std::mutex> lock(queue_mtx);
+        queue.emplace(Level::INFO, std::move(line));
+    }
+    cv.notify_one();
 }
 
 void Logger::error(const std::string &msg) {
-    std::lock_guard<std::mutex> lock(mtx);
     std::string line = timestamp() + " ERROR: " + msg + "\n";
-    std::cerr << line;
-    if (file.is_open()) file << line;
+    {
+        std::lock_guard<std::mutex> lock(queue_mtx);
+        queue.emplace(Level::ERROR, std::move(line));
+    }
+    cv.notify_one();
+}
+
+void Logger::worker() {
+    while (true) {
+        std::unique_lock<std::mutex> lock(queue_mtx);
+        cv.wait(lock, [] { return !queue.empty() || !running; });
+        if (queue.empty() && !running) break;
+        auto item = std::move(queue.front());
+        queue.pop();
+        lock.unlock();
+
+        {
+            std::lock_guard<std::mutex> lk(console_mtx);
+            if (item.first == Level::ERROR)
+                std::cerr << item.second;
+            else
+                std::cout << item.second;
+        }
+        if (file.is_open()) {
+            std::lock_guard<std::mutex> lk(file_mtx);
+            file << item.second;
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
- Replace global mutex logger with asynchronous queue and dedicated thread
- Separate console and file locks and add log-level filtering

## Testing
- `cmake -S port2-reduce-futex -B port2-reduce-futex/build`
- `cmake --build port2-reduce-futex/build`


------
https://chatgpt.com/codex/tasks/task_e_689672ac2630833299d696655b00d598