### PR TITLE
Refactor status reporting

### DIFF
--- a/benchmark/include/status.h
+++ b/benchmark/include/status.h
@@ -1,10 +1,11 @@
 #pragma once
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 
 namespace status {
 
-void updateRate(double r);
+void updateRate(uint64_t count, std::chrono::steady_clock::time_point now);
 void updateLatency(uint64_t l);
 void printStatus();
 

--- a/benchmark/src/analyzer.cpp
+++ b/benchmark/src/analyzer.cpp
@@ -7,10 +7,7 @@
 
 void startAnalyzer(SampleQueue& queue, std::atomic<bool>& running) {
     uint64_t currentLatency = 0;
-    auto nextPrint = std::chrono::steady_clock::now() +
-                     std::chrono::milliseconds(500);
     status::updateLatency(currentLatency);
-    status::printStatus();
 
     while (running.load()) {
         bool processed = false;
@@ -23,13 +20,6 @@ void startAnalyzer(SampleQueue& queue, std::atomic<bool>& running) {
             currentLatency = latency;
             status::updateLatency(currentLatency);
             processed = true;
-        }
-
-        auto now = std::chrono::steady_clock::now();
-        if (now >= nextPrint) {
-            status::updateLatency(currentLatency);
-            status::printStatus();
-            nextPrint += std::chrono::milliseconds(500);
         }
 
         if (!processed) {
@@ -48,5 +38,4 @@ void startAnalyzer(SampleQueue& queue, std::atomic<bool>& running) {
         status::updateLatency(currentLatency);
     }
     status::updateLatency(currentLatency);
-    status::printStatus();
 }

--- a/benchmark/src/status.cpp
+++ b/benchmark/src/status.cpp
@@ -1,5 +1,7 @@
 #include "status.h"
 #include "scenario.h"
+#include <chrono>
+#include <deque>
 #include <iostream>
 #include <mutex>
 #include <sys/ioctl.h>
@@ -10,9 +12,31 @@ namespace status {
 static std::atomic<double> gRate{0.0};
 static std::atomic<uint64_t> gLatency{0};
 static std::mutex printMutex;
+static std::mutex rateMutex;
+static std::deque<std::pair<std::chrono::steady_clock::time_point, uint64_t>>
+    rateHistory;
+static constexpr std::chrono::seconds RATE_WINDOW{1};
 
-void updateRate(double r) {
-    gRate.store(r, std::memory_order_relaxed);
+void updateRate(uint64_t count, std::chrono::steady_clock::time_point now) {
+    std::lock_guard<std::mutex> lock(rateMutex);
+    rateHistory.emplace_back(now, count);
+    auto cutoff = now - RATE_WINDOW;
+    while (!rateHistory.empty() && rateHistory.front().first < cutoff) {
+        rateHistory.pop_front();
+    }
+    if (rateHistory.size() >= 2) {
+        auto first = rateHistory.front();
+        auto last = rateHistory.back();
+        double dt =
+            std::chrono::duration_cast<std::chrono::duration<double>>(last.first -
+                                                                    first.first)
+                .count();
+        uint64_t dp = last.second - first.second;
+        double r = dt > 0 ? static_cast<double>(dp) / dt : 0.0;
+        gRate.store(r, std::memory_order_relaxed);
+    } else {
+        gRate.store(0.0, std::memory_order_relaxed);
+    }
 }
 
 void updateLatency(uint64_t l) {


### PR DESCRIPTION
## Summary
- consolidate status reporting to generator and smooth rate updates over 1s window
- remove analyzer status output to avoid contention

## Testing
- `cmake -S benchmark -B build-benchmark`
- `cmake --build build-benchmark`


------
https://chatgpt.com/codex/tasks/task_e_68967eaa5bd08332a089e2ad9ed13c1e