### PR TITLE
Optimize generator message handling

### DIFF
--- a/benchmark/src/generator.cpp
+++ b/benchmark/src/generator.cpp
@@ -10,7 +10,11 @@
 #include <unistd.h>
 #include <sys/select.h>
 #include <nlohmann/json.hpp>
+#include <nlohmann/detail/output/output_adapters.hpp>
+#include <nlohmann/detail/output/serializer.hpp>
 #include <atomic>
+#include <string>
+#include <cstdio>
 
 using json = nlohmann::json;
 
@@ -91,6 +95,42 @@ void startGenerator(const GeneratorParams& params,
     uint64_t packet_id = 0;
     uint64_t flow_id = 1;
 
+    // Pre-build JSON message template
+    json j = {
+        {"alias", "benchmark"},
+        {"source", "benchmark"},
+        {"thread_id", 0},
+        {"packet_id", packet_id},
+        {"flow_event_id", 1},
+        {"flow_event_name", "update"},
+        {"flow_id", flow_id},
+        {"flow_state", "info"},
+        {"flow_src_packets_processed", 1},
+        {"flow_dst_packets_processed", 1},
+        {"flow_first_seen", 0},
+        {"flow_src_last_pkt_time", 0},
+        {"flow_dst_last_pkt_time", 0},
+        {"flow_idle_time", 10},
+        {"flow_src_min_l4_payload_len", 0},
+        {"flow_dst_min_l4_payload_len", 0},
+        {"flow_src_max_l4_payload_len", 0},
+        {"flow_dst_max_l4_payload_len", 0},
+        {"flow_src_tot_l4_payload_len", 0},
+        {"flow_dst_tot_l4_payload_len", 0},
+        {"flow_datalink", 1},
+        {"flow_max_packets", 10},
+        {"l3_proto", "ip4"},
+        {"l4_proto", "tcp"},
+        {"midstream", 0},
+        {"thread_ts_usec", 0},
+        {"src_ip", "192.168.0.1"},
+        {"dst_ip", "192.168.0.2"}
+    };
+
+    // Reusable buffer for serialized messages
+    std::string message;
+    message.reserve(512);
+
     // Track current scenario to print a message whenever it changes
     ScenarioPtr lastScenario =
         std::atomic_load_explicit(&gScenario, std::memory_order_acquire);
@@ -114,46 +154,28 @@ void startGenerator(const GeneratorParams& params,
             uint64_t ts_usec = std::chrono::duration_cast<std::chrono::microseconds>(
                 std::chrono::system_clock::now().time_since_epoch()).count();
 
-        json j = {
-            {"alias", "benchmark"},
-            {"source", "benchmark"},
-            {"thread_id", 0},
-            {"packet_id", packet_id++},
-            {"flow_event_id", 1},
-            {"flow_event_name", "update"},
-            {"flow_id", flow_id},
-            {"flow_state", "info"},
-            {"flow_src_packets_processed", 1},
-            {"flow_dst_packets_processed", 1},
-            {"flow_first_seen", ts_usec},
-            {"flow_src_last_pkt_time", ts_usec},
-            {"flow_dst_last_pkt_time", ts_usec},
-            {"flow_idle_time", 10},
-            {"flow_src_min_l4_payload_len", 0},
-            {"flow_dst_min_l4_payload_len", 0},
-            {"flow_src_max_l4_payload_len", 0},
-            {"flow_dst_max_l4_payload_len", 0},
-            {"flow_src_tot_l4_payload_len", 0},
-            {"flow_dst_tot_l4_payload_len", 0},
-            {"flow_datalink", 1},
-            {"flow_max_packets", 10},
-            {"l3_proto", "ip4"},
-            {"l4_proto", "tcp"},
-            {"midstream", 0},
-            {"thread_ts_usec", ts_usec},
-            {"src_ip", "192.168.0.1"},
-            {"dst_ip", "192.168.0.2"}
-        };
+            // update dynamic fields
+            j["packet_id"] = packet_id++;
+            j["flow_id"] = flow_id;
+            j["flow_first_seen"] = ts_usec;
+            j["flow_src_last_pkt_time"] = ts_usec;
+            j["flow_dst_last_pkt_time"] = ts_usec;
+            j["thread_ts_usec"] = ts_usec;
 
-        std::string message_body = j.dump();
-        char prefix[6];
-        std::snprintf(prefix, sizeof(prefix), "%05zu", message_body.size());
-        std::string message = std::string(prefix) + message_body;
+            message.clear();
+            message.resize(5); // placeholder for length prefix
+            {
+                nlohmann::detail::output_adapter<char> oa(message);
+                nlohmann::detail::serializer<json> writer(
+                    oa, ' ', nlohmann::detail::error_handler_t::strict);
+                writer.dump(j, false, false, 0);
+            }
+            std::snprintf(message.data(), 6, "%05zu", message.size() - 5);
 
-        if (send(client, message.data(), message.size(), 0) < 0) {
-            std::cerr << "Generator: send() failed, exiting" << std::endl;
-            break;
-        }
+            if (send(client, message.data(), message.size(), 0) < 0) {
+                std::cerr << "Generator: send() failed, exiting" << std::endl;
+                break;
+            }
 
             auto interval = nextInterval(*currentScenario);
             status::updateRate(1'000'000.0 / interval.count());

--- a/benchmark/src/scenario.cpp
+++ b/benchmark/src/scenario.cpp
@@ -5,7 +5,14 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 
-static const ScenarioConfig defaults{};
+// Set default scenario with higher base rate to stress the generator
+static ScenarioConfig makeDefaults() {
+    ScenarioConfig cfg{};
+    cfg.idle_rate = 10'000; // pkts/s
+    return cfg;
+}
+
+static const ScenarioConfig defaults = makeDefaults();
 ScenarioPtr gScenario{std::make_shared<ScenarioConfig>(defaults)};
 
 using us = std::chrono::microseconds;
@@ -84,7 +91,7 @@ ScenarioFile loadScenarioFile(const std::string& path)
                   << ", using defaults\n";
         ScenarioConfig idle;
         idle.mode = Mode::IDLE;
-        idle.idle_rate = 100;
+        idle.idle_rate = 10'000;
 
         ScenarioConfig burst = idle;
         burst.mode = Mode::BURST;


### PR DESCRIPTION
## Summary
- Build JSON payload template once and update only volatile fields
- Serialize directly into a reusable buffer to avoid per-packet string allocations
- Use higher default idle rate for scenarios to better exercise generator throughput

## Testing
- `cmake .. && make -j$(nproc)` in `benchmark` module
- `./build/benchmark config_dummy.json` (failed to bind port: cleanup)


------
https://chatgpt.com/codex/tasks/task_e_689b09dfe4ac83328486d975defcee9f