### PR TITLE
Add multi-event generator with configurable probabilities

### DIFF
--- a/benchmark/config.json
+++ b/benchmark/config.json
@@ -12,5 +12,11 @@
     "port": 7000,
     "rate": 2.0,
     "message_size": 128
+  },
+  "eventProbabilities": {
+    "flow": 0.25,
+    "daemon": 0.25,
+    "error": 0.25,
+    "packet": 0.25
   }
 }

--- a/benchmark/include/config.h
+++ b/benchmark/include/config.h
@@ -10,6 +10,13 @@ struct GeneratorParams {
     size_t message_size;
 };
 
+struct EventProbabilities {
+    double flow{0.25};
+    double daemon{0.25};
+    double error{0.25};
+    double packet{0.25};
+};
+
 struct Config {
     std::string loggerType;      // "python" or "binary"
     std::string loggerModule;
@@ -17,8 +24,9 @@ struct Config {
     std::string loggerConfigPath;
     std::string outputFilePath;
     std::string scenarioPath;
-    bool        straceEnabled;   // run logger via strace
-    GeneratorParams generatorParams;
+    bool                straceEnabled;   // run logger via strace
+    GeneratorParams     generatorParams;
+    EventProbabilities  eventProbabilities;
 };
 
 Config loadConfig(const std::string& path);

--- a/benchmark/include/generator.h
+++ b/benchmark/include/generator.h
@@ -1,5 +1,9 @@
 #ifndef GENERATOR_H
 #define GENERATOR_H
 #include <atomic>
-void startGenerator(int clientSock, std::atomic<bool>& running);
+#include "config.h"
+
+void startGenerator(int clientSock,
+                    std::atomic<bool>& running,
+                    const EventProbabilities& probs);
 #endif // GENERATOR_H

--- a/benchmark/src/config.cpp
+++ b/benchmark/src/config.cpp
@@ -23,6 +23,7 @@ Config loadConfig(const std::string& path) {
         cfg.scenarioPath     = "scenarios.json";
         cfg.straceEnabled    = false;
         cfg.generatorParams  = {"127.0.0.1", 7000, 1.0, 128};
+        cfg.eventProbabilities = {0.25, 0.25, 0.25, 0.25};
         return cfg;
     }
 
@@ -45,6 +46,12 @@ Config loadConfig(const std::string& path) {
     cfg.generatorParams.port         = gj.value("port", 7000);
     cfg.generatorParams.rate         = gj.value("rate", 1.0);
     cfg.generatorParams.message_size = gj.value("message_size", 128);
+
+    auto ep = j.value("eventProbabilities", json::object());
+    cfg.eventProbabilities.flow   = ep.value("flow", 0.25);
+    cfg.eventProbabilities.daemon = ep.value("daemon", 0.25);
+    cfg.eventProbabilities.error  = ep.value("error", 0.25);
+    cfg.eventProbabilities.packet = ep.value("packet", 0.25);
 
     return cfg;
 }

--- a/benchmark/src/generator.cpp
+++ b/benchmark/src/generator.cpp
@@ -9,39 +9,44 @@
 #include <nlohmann/json.hpp>
 #include <nlohmann/detail/output/output_adapters.hpp>
 #include <nlohmann/detail/output/serializer.hpp>
-#include <atomic>
-#include <string>
-#include <cstdio>
+#include <random>
+#include <cstdlib>
 
 using json = nlohmann::json;
 
-void startGenerator(int client, std::atomic<bool>& running) {
-    // allow the logger some time to initialize
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+enum class EventType { Flow, Daemon, Error, Packet };
 
-    auto nextSend = std::chrono::steady_clock::now();
-    auto lastPrint = nextSend;
-    auto nextPrint = nextSend + std::chrono::milliseconds(500);
-    uint64_t lastPacket = 0;
-    status::updateRate(0.0);
-    uint64_t packet_id = 0;
-    uint64_t flow_id = 1;
+static EventType pickEventType(std::mt19937& rng,
+                               const EventProbabilities& probs) {
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    double x = dist(rng);
+    double cumulative = probs.flow;
+    if (x < cumulative) return EventType::Flow;
+    cumulative += probs.daemon;
+    if (x < cumulative) return EventType::Daemon;
+    cumulative += probs.error;
+    if (x < cumulative) return EventType::Error;
+    return EventType::Packet;
+}
 
-    // Pre-build JSON message template
-    json j = {
+static json buildFlowEvent(uint64_t packetId,
+                           uint64_t flowEventId,
+                           uint64_t flowId,
+                           uint64_t ts_usec) {
+    return {
         {"alias", "benchmark"},
         {"source", "benchmark"},
         {"thread_id", 0},
-        {"packet_id", packet_id},
-        {"flow_event_id", 1},
+        {"packet_id", packetId},
+        {"flow_event_id", flowEventId},
         {"flow_event_name", "update"},
-        {"flow_id", flow_id},
+        {"flow_id", flowId},
         {"flow_state", "info"},
         {"flow_src_packets_processed", 1},
         {"flow_dst_packets_processed", 1},
-        {"flow_first_seen", 0},
-        {"flow_src_last_pkt_time", 0},
-        {"flow_dst_last_pkt_time", 0},
+        {"flow_first_seen", ts_usec},
+        {"flow_src_last_pkt_time", ts_usec},
+        {"flow_dst_last_pkt_time", ts_usec},
         {"flow_idle_time", 10},
         {"flow_src_min_l4_payload_len", 0},
         {"flow_dst_min_l4_payload_len", 0},
@@ -54,16 +59,119 @@ void startGenerator(int client, std::atomic<bool>& running) {
         {"l3_proto", "ip4"},
         {"l4_proto", "tcp"},
         {"midstream", 0},
-        {"thread_ts_usec", 0},
+        {"thread_ts_usec", ts_usec},
         {"src_ip", "192.168.0.1"},
         {"dst_ip", "192.168.0.2"}
     };
+}
 
-    // Reusable buffer for serialized messages
+static json buildDaemonEvent(uint64_t packetId,
+                             uint64_t daemonEventId,
+                             uint64_t ts_usec) {
+    return {
+        {"alias", "benchmark"},
+        {"source", "benchmark"},
+        {"thread_id", 0},
+        {"packet_id", packetId},
+        {"daemon_event_id", daemonEventId},
+        {"daemon_event_name", "status"},
+        {"packets-captured", 0},
+        {"packets-processed", 0},
+        {"total-skipped-flows", 0},
+        {"total-l4-payload-len", 0},
+        {"total-not-detected-flows", 0},
+        {"total-guessed-flows", 0},
+        {"total-detected-flows", 0},
+        {"total-detection-updates", 0},
+        {"total-updates", 0},
+        {"current-active-flows", 0},
+        {"total-active-flows", 0},
+        {"total-idle-flows", 0},
+        {"total-compressions", 0},
+        {"total-compression-diff", 0},
+        {"current-compression-diff", 0},
+        {"total-events-serialized", 0},
+        {"global_ts_usec", ts_usec}
+    };
+}
+
+static json buildErrorEvent(uint64_t packetId,
+                            uint64_t errorEventId,
+                            uint64_t ts_usec) {
+    return {
+        {"alias", "benchmark"},
+        {"source", "benchmark"},
+        {"thread_id", 0},
+        {"packet_id", packetId},
+        {"error_event_id", errorEventId},
+        {"error_event_name", "Unknown packet type"},
+        {"datalink", 1},
+        {"threshold_n", 1},
+        {"threshold_n_max", 1},
+        {"threshold_time", 1},
+        {"threshold_ts_usec", ts_usec},
+        {"layer_type", 1},
+        {"global_ts_usec", ts_usec}
+    };
+}
+
+static json buildPacketEvent(uint64_t packetId,
+                             uint64_t packetEventId,
+                             uint64_t& flowId,
+                             uint64_t& flowPacketId,
+                             uint64_t ts_usec) {
+    json j = {
+        {"alias", "benchmark"},
+        {"source", "benchmark"},
+        {"packet_id", packetId},
+        {"packet_event_id", packetEventId},
+        {"pkt_caplen", 64},
+        {"pkt_type", 0},
+        {"pkt_l3_offset", 14},
+        {"pkt_l4_offset", 34},
+        {"pkt_len", 64},
+        {"pkt_l4_len", 20},
+        {"thread_ts_usec", ts_usec}
+    };
+    if (std::rand() % 2 == 0) {
+        j["packet_event_name"] = "packet";
+    } else {
+        j["packet_event_name"] = "packet-flow";
+        j["thread_id"] = 0;
+        j["flow_id"] = ++flowId;
+        j["flow_packet_id"] = flowPacketId++;
+        j["flow_src_last_pkt_time"] = ts_usec;
+        j["flow_dst_last_pkt_time"] = ts_usec;
+        j["flow_idle_time"] = 10;
+    }
+    return j;
+}
+
+void startGenerator(int client,
+                    std::atomic<bool>& running,
+                    const EventProbabilities& probs) {
+    // allow the logger some time to initialize
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    auto nextSend = std::chrono::steady_clock::now();
+    auto lastPrint = nextSend;
+    auto nextPrint = nextSend + std::chrono::milliseconds(500);
+    uint64_t lastPacket = 0;
+    status::updateRate(0.0);
+
+    uint64_t packetId = 0;
+    uint64_t flowEventId = 0;
+    uint64_t daemonEventId = 0;
+    uint64_t errorEventId = 0;
+    uint64_t packetEventId = 0;
+    uint64_t flowId = 0;
+    uint64_t flowPacketId = 0;
+
+    std::mt19937 rng(std::random_device{}());
+
     std::string message;
     message.reserve(512);
 
-    // Track current scenario to print a message whenever it changes
     ScenarioPtr lastScenario =
         std::atomic_load_explicit(&gScenario, std::memory_order_acquire);
     std::cout << "[Generator] Scenario " << modeToString(lastScenario->mode)
@@ -83,16 +191,33 @@ void startGenerator(int client, std::atomic<bool>& running) {
         }
 
         if (now >= nextSend) {
-            uint64_t ts_usec = std::chrono::duration_cast<std::chrono::microseconds>(
-                std::chrono::system_clock::now().time_since_epoch()).count();
+            uint64_t ts_usec =
+                std::chrono::duration_cast<std::chrono::microseconds>(
+                    std::chrono::system_clock::now().time_since_epoch())
+                    .count();
 
-            // update dynamic fields
-            j["packet_id"] = packet_id++;
-            j["flow_id"] = flow_id;
-            j["flow_first_seen"] = ts_usec;
-            j["flow_src_last_pkt_time"] = ts_usec;
-            j["flow_dst_last_pkt_time"] = ts_usec;
-            j["thread_ts_usec"] = ts_usec;
+            json j;
+            EventType type = pickEventType(rng, probs);
+            switch (type) {
+            case EventType::Flow:
+                j = buildFlowEvent(packetId, flowEventId, ++flowId, ts_usec);
+                ++flowEventId;
+                break;
+            case EventType::Daemon:
+                j = buildDaemonEvent(packetId, daemonEventId, ts_usec);
+                ++daemonEventId;
+                break;
+            case EventType::Error:
+                j = buildErrorEvent(packetId, errorEventId, ts_usec);
+                ++errorEventId;
+                break;
+            case EventType::Packet:
+                j = buildPacketEvent(packetId, packetEventId, flowId, flowPacketId,
+                                     ts_usec);
+                ++packetEventId;
+                break;
+            }
+            ++packetId;
 
             message.clear();
             message.resize(5); // placeholder for length prefix
@@ -126,12 +251,13 @@ void startGenerator(int client, std::atomic<bool>& running) {
                 std::chrono::duration_cast<std::chrono::microseconds>(now - lastPrint)
                     .count() /
                 1e6;
-            double rate = elapsed > 0 ? (packet_id - lastPacket) / elapsed : 0.0;
+            double rate = elapsed > 0 ? (packetId - lastPacket) / elapsed : 0.0;
             status::updateRate(rate);
             status::printStatus();
             lastPrint = now;
-            lastPacket = packet_id;
+            lastPacket = packetId;
             nextPrint += std::chrono::milliseconds(500);
         }
     }
 }
+

--- a/benchmark/src/main.cpp
+++ b/benchmark/src/main.cpp
@@ -197,7 +197,10 @@ int main(int argc, char* argv[]) {
     }
 
     // Start generator thread now that a client is connected
-    std::thread genThread(startGenerator, clientSock, std::ref(running));
+    std::thread genThread(startGenerator,
+                          clientSock,
+                          std::ref(running),
+                          config.eventProbabilities);
 
     // Start watcher and analyzer threads
     std::thread watchThread(startWatcher,


### PR DESCRIPTION
## Summary
- allow configuring event type probabilities via `eventProbabilities` in config
- extend generator to emit daemon, error, and packet events in addition to flow events
- track separate IDs per event type and randomly choose events based on configured probabilities

## Testing
- `cmake -S benchmark -B benchmark/build`
- `cmake --build benchmark/build`

------
https://chatgpt.com/codex/tasks/task_e_68a05f9545d083329c8a185a0350ab1d