### PR TITLE
Allow configuring heiDPI event parameters in benchmark

### DIFF
--- a/benchmark/config.json
+++ b/benchmark/config.json
@@ -18,5 +18,11 @@
     "daemon": 0.25,
     "error": 0.25,
     "packet": 0.25
+  },
+  "eventParams": {
+    "--show-flow-events": "1",
+    "--show-daemon-events": "1",
+    "--show-packet-events": "1",
+    "--show-error-events": "1"
   }
 }

--- a/benchmark/include/config.h
+++ b/benchmark/include/config.h
@@ -2,6 +2,8 @@
 #define CONFIG_H
 
 #include <string>
+#include <vector>
+#include <utility>
 
 struct GeneratorParams {
     std::string host;
@@ -27,6 +29,7 @@ struct Config {
     bool                straceEnabled;   // run logger via strace
     GeneratorParams     generatorParams;
     EventProbabilities  eventProbabilities;
+    std::vector<std::pair<std::string, std::string>> loggerEventParams;
 };
 
 Config loadConfig(const std::string& path);

--- a/benchmark/include/logger_launcher.h
+++ b/benchmark/include/logger_launcher.h
@@ -2,25 +2,31 @@
 #define LOGGER_LAUNCHER_H
 #include <sys/types.h>
 #include <string>
+#include <vector>
+#include <utility>
 
 pid_t launchPythonLogger(const std::string& moduleName,
                          const std::string& host,
                          int port,
-                         const std::string& configPath);
+                         const std::string& configPath,
+                         const std::vector<std::pair<std::string, std::string>>& eventParams);
 
 pid_t launchBinaryLogger(const std::string& path,
                          const std::string& host,
                          int port,
-                         const std::string& configPath);
+                         const std::string& configPath,
+                         const std::vector<std::pair<std::string, std::string>>& eventParams);
 
 pid_t launchPythonLoggerStrace(const std::string& moduleName,
                                const std::string& host,
                                int port,
-                               const std::string& configPath);
+                               const std::string& configPath,
+                               const std::vector<std::pair<std::string, std::string>>& eventParams);
 
 pid_t launchBinaryLoggerStrace(const std::string& path,
                                const std::string& host,
                                int port,
-                               const std::string& configPath);
+                               const std::string& configPath,
+                               const std::vector<std::pair<std::string, std::string>>& eventParams);
 
 #endif // LOGGER_LAUNCHER_H

--- a/benchmark/src/config.cpp
+++ b/benchmark/src/config.cpp
@@ -24,6 +24,12 @@ Config loadConfig(const std::string& path) {
         cfg.straceEnabled    = false;
         cfg.generatorParams  = {"127.0.0.1", 7000, 1.0, 128};
         cfg.eventProbabilities = {0.25, 0.25, 0.25, 0.25};
+        cfg.loggerEventParams = {
+            {"--show-flow-events", "1"},
+            {"--show-daemon-events", "1"},
+            {"--show-packet-events", "1"},
+            {"--show-error-events", "1"}
+        };
         return cfg;
     }
 
@@ -52,6 +58,11 @@ Config loadConfig(const std::string& path) {
     cfg.eventProbabilities.daemon = ep.value("daemon", 0.25);
     cfg.eventProbabilities.error  = ep.value("error", 0.25);
     cfg.eventProbabilities.packet = ep.value("packet", 0.25);
+
+    auto params = j.value("eventParams", json::object());
+    for (auto it = params.begin(); it != params.end(); ++it) {
+        cfg.loggerEventParams.emplace_back(it.key(), it.value().get<std::string>());
+    }
 
     return cfg;
 }

--- a/benchmark/src/logger_launcher.cpp
+++ b/benchmark/src/logger_launcher.cpp
@@ -2,21 +2,31 @@
 #include <unistd.h>
 #include <iostream>
 #include <filesystem>
+#include <vector>
 
 pid_t launchPythonLogger(const std::string& moduleName,
                          const std::string& host,
                          int port,
-                         const std::string& configPath) {
+                         const std::string& configPath,
+                         const std::vector<std::pair<std::string, std::string>>& eventParams) {
     pid_t pid = fork();
     if (pid == 0) {
-        execlp("python3", "python3",
-               "-m", moduleName.c_str(),
-               "--host", host.c_str(),
-               "--port", std::to_string(port).c_str(),
-               "--write", ".",
-               "--config", configPath.c_str(),
-               "--show-flow-events", "1",
-               nullptr);
+        std::vector<std::string> args = {
+            "python3",
+            "-m", moduleName,
+            "--host", host,
+            "--port", std::to_string(port),
+            "--write", ".",
+            "--config", configPath
+        };
+        for (const auto& [k, v] : eventParams) {
+            args.push_back(k);
+            args.push_back(v);
+        }
+        std::vector<char*> cargs;
+        for (auto& a : args) cargs.push_back(const_cast<char*>(a.c_str()));
+        cargs.push_back(nullptr);
+        execvp("python3", cargs.data());
         std::cerr << "Failed to launch heiDPI_logger" << std::endl;
         _exit(1);
     } else if (pid < 0) {
@@ -28,16 +38,25 @@ pid_t launchPythonLogger(const std::string& moduleName,
 pid_t launchBinaryLogger(const std::string& path,
                          const std::string& host,
                          int port,
-                         const std::string& configPath) {
+                         const std::string& configPath,
+                         const std::vector<std::pair<std::string, std::string>>& eventParams) {
     pid_t pid = fork();
     if (pid == 0) {
-        execl(path.c_str(), path.c_str(),
-              "--host", host.c_str(),
-              "--port", std::to_string(port).c_str(),
-              "--write", ".",
-              "--config", configPath.c_str(),
-              "--show-flow-events", "1",
-              nullptr);
+        std::vector<std::string> args = {
+            path,
+            "--host", host,
+            "--port", std::to_string(port),
+            "--write", ".",
+            "--config", configPath
+        };
+        for (const auto& [k, v] : eventParams) {
+            args.push_back(k);
+            args.push_back(v);
+        }
+        std::vector<char*> cargs;
+        for (auto& a : args) cargs.push_back(const_cast<char*>(a.c_str()));
+        cargs.push_back(nullptr);
+        execvp(path.c_str(), cargs.data());
         std::cerr << "Failed to launch heiDPI logger binary" << std::endl;
         _exit(1);
     } else if (pid < 0) {
@@ -49,18 +68,27 @@ pid_t launchBinaryLogger(const std::string& path,
 pid_t launchPythonLoggerStrace(const std::string& moduleName,
                                const std::string& host,
                                int port,
-                               const std::string& configPath) {
+                               const std::string& configPath,
+                               const std::vector<std::pair<std::string, std::string>>& eventParams) {
     pid_t pid = fork();
     if (pid == 0) {
-        execlp("strace", "strace",
-               "-f", "-c", "-o", "strace_summary.log",
-               "python3", "-m", moduleName.c_str(),
-               "--host", host.c_str(),
-               "--port", std::to_string(port).c_str(),
-               "--write", ".",
-               "--config", configPath.c_str(),
-               "--show-flow-events", "1",
-               nullptr);
+        std::vector<std::string> args = {
+            "strace",
+            "-f", "-c", "-o", "strace_summary.log",
+            "python3", "-m", moduleName,
+            "--host", host,
+            "--port", std::to_string(port),
+            "--write", ".",
+            "--config", configPath
+        };
+        for (const auto& [k, v] : eventParams) {
+            args.push_back(k);
+            args.push_back(v);
+        }
+        std::vector<char*> cargs;
+        for (auto& a : args) cargs.push_back(const_cast<char*>(a.c_str()));
+        cargs.push_back(nullptr);
+        execvp("strace", cargs.data());
         std::cerr << "Failed to launch heiDPI_logger with strace" << std::endl;
         _exit(1);
     } else if (pid < 0) {
@@ -72,19 +100,28 @@ pid_t launchPythonLoggerStrace(const std::string& moduleName,
 pid_t launchBinaryLoggerStrace(const std::string& path,
                                const std::string& host,
                                int port,
-                               const std::string& configPath) {
+                               const std::string& configPath,
+                               const std::vector<std::pair<std::string, std::string>>& eventParams) {
     pid_t pid = fork();
     if (pid == 0) {
         std::string absPath = std::filesystem::absolute(path).string();
-        execlp("strace", "strace",
-               "-f", "-c", "-o", "strace_summary.log",
-               absPath.c_str(),
-               "--host", host.c_str(),
-               "--port", std::to_string(port).c_str(),
-               "--write", ".",
-               "--config", configPath.c_str(),
-               "--show-flow-events", "1",
-               nullptr);
+        std::vector<std::string> args = {
+            "strace",
+            "-f", "-c", "-o", "strace_summary.log",
+            absPath,
+            "--host", host,
+            "--port", std::to_string(port),
+            "--write", ".",
+            "--config", configPath
+        };
+        for (const auto& [k, v] : eventParams) {
+            args.push_back(k);
+            args.push_back(v);
+        }
+        std::vector<char*> cargs;
+        for (auto& a : args) cargs.push_back(const_cast<char*>(a.c_str()));
+        cargs.push_back(nullptr);
+        execvp("strace", cargs.data());
         std::cerr << "Failed to launch heiDPI logger binary with strace" << std::endl;
         _exit(1);
     } else if (pid < 0) {

--- a/benchmark/src/main.cpp
+++ b/benchmark/src/main.cpp
@@ -163,13 +163,15 @@ int main(int argc, char* argv[]) {
                 config.loggerBinary,
                 config.generatorParams.host,
                 config.generatorParams.port,
-                config.loggerConfigPath);
+                config.loggerConfigPath,
+                config.loggerEventParams);
         } else {
             loggerPid = launchPythonLoggerStrace(
                 config.loggerModule,
                 config.generatorParams.host,
                 config.generatorParams.port,
-                config.loggerConfigPath);
+                config.loggerConfigPath,
+                config.loggerEventParams);
         }
     } else {
         if (config.loggerType == "binary") {
@@ -177,13 +179,15 @@ int main(int argc, char* argv[]) {
                 config.loggerBinary,
                 config.generatorParams.host,
                 config.generatorParams.port,
-                config.loggerConfigPath);
+                config.loggerConfigPath,
+                config.loggerEventParams);
         } else {
             loggerPid = launchPythonLogger(
                 config.loggerModule,
                 config.generatorParams.host,
                 config.generatorParams.port,
-                config.loggerConfigPath);
+                config.loggerConfigPath,
+                config.loggerEventParams);
         }
     }
     std::cout << "Started heiDPI_logger (PID: " << loggerPid << ")" << std::endl;


### PR DESCRIPTION
## Summary
- allow specifying heiDPI event command-line arguments via `eventParams` in `config.json`
- parse and store event parameters in Config and pass them to the logger launcher
- launch heiDPI with the configured event parameters (works for strace and normal modes)
- provide defaults for all four event type flags in configuration

## Testing
- `cd benchmark && cmake -S . -B build`
- `cd benchmark && cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68a07a36bfd48332ac51ef8abbcd7654